### PR TITLE
Add Initial Slash Commands

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -9,8 +9,13 @@ On the developer portal dashboard, you will want to select your new application 
 
 Create a `.env` file and fill out the following value(s). If you do not know your bot token, you can refresh it on the application's main page.
 
+Setting ENV to `production` value will register commands globally.
+
 ```
+ENV=
 BOT_TOKEN=
+CLIENT_ID=
+GUILD_ID=
 ```
 
 ## Inviting 
@@ -27,3 +32,5 @@ You should see your bot join the selected discord server.
 ## Testing the Bot
 
 Running the startup command `node index.js` will display a message in terminal. If you look at the users list of the server the bot was invite to, the bot will be online.
+
+The bot utilizes slash commands in it's current state. Typing `/emi` or `/lookup` will generate a response from the bot.

--- a/commands/emi.js
+++ b/commands/emi.js
@@ -1,0 +1,10 @@
+const { SlashCommandBuilder } = require('@discordjs/builders');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName("emi")
+        .setDescription("Emi command"),
+    async execute(interation) {
+        interation.reply("This is a new EMI command.");
+    }
+}

--- a/commands/lookup.js
+++ b/commands/lookup.js
@@ -1,0 +1,10 @@
+const { SlashCommandBuilder } = require('@discordjs/builders');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName("lookup")
+        .setDescription("Lookup a user"),
+    async execute(interation) {
+        interation.reply("This is a new user lookup command.");
+    }
+}

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ client.once('ready', () => {
 
 	(async () => {
 		try {
-			if(process.env.ENV === "PRODUCTION") {
+			if(process.env.ENV === "production") {
 				await rest.put(Routes.applicationCommands(process.env.CLIENT_ID), {
 					body: commands
 				});

--- a/index.js
+++ b/index.js
@@ -1,7 +1,10 @@
-const { Client, GatewayIntentBits } = require('discord.js');
-const dotenv = require('dotenv');
+const fs = require("fs");
+const { REST } = require("@discordjs/rest");
+const { Routes } = require("discord-api-types/v10");
+const { Client, GatewayIntentBits, Collection } = require('discord.js');
 
 // load env config
+const dotenv = require('dotenv');
 dotenv.config({path: './.env'});
 
 const client = new Client({
@@ -10,8 +13,59 @@ const client = new Client({
     ]
 });
 
-client.on('ready', () => {
+const commandFiles = fs.readdirSync("./commands").filter(file => file.endsWith(".js"));
+const commands = [];
+client.commands = new Collection();
+
+for(const file of commandFiles) {
+	const command = require(`./commands/${file}`);
+	commands.push(command.data.toJSON());
+	client.commands.set(command.data.name, command);
+}
+
+client.once('ready', () => {
     console.info(`Logged in as ${client.user.tag}!`);
+
+	const rest = new REST({
+		version: "10"
+	}).setToken(process.env.BOT_TOKEN);
+
+	(async () => {
+		try {
+			if(process.env.ENV === "PRODUCTION") {
+				await rest.put(Routes.applicationCommands(process.env.CLIENT_ID), {
+					body: commands
+				});
+				console.log("Successfully registered commands globally.")
+			} else {
+				await rest.put(Routes.applicationGuildCommands(process.env.CLIENT_ID, process.env.GUILD_ID), {
+					body: commands
+				});
+				console.log("Successfully registered commands locally.")
+			}
+		} catch (err) {
+			if (err) console.error(err);
+		}
+	})();
+});
+
+client.on("interactionCreate", async interaction => {
+	if(!interaction.type === interaction.ApplicationCommand) return;
+	
+	const command = client.commands.get(interaction.commandName);
+
+	if(!command) return;
+
+	try {
+		await command.execute(interaction);
+	} catch (err) {
+		if (err) console.log(err);
+
+		await interaction.reply({
+			content: "An error occured while executing that command.",
+			emphemeral: true
+		});
+	}
 });
 
 client.login(process.env.BOT_TOKEN);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "discord-api-types": "^0.37.2",
         "discord.js": "^14.0.3",
         "dotenv": "^16.0.1"
       },
@@ -30,6 +31,11 @@
       "engines": {
         "node": ">=16.9.0"
       }
+    },
+    "node_modules/@discordjs/builders/node_modules/discord-api-types": {
+      "version": "0.36.3",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.36.3.tgz",
+      "integrity": "sha512-bz/NDyG0KBo/tY14vSkrwQ/n3HKPf87a0WFW/1M9+tXYK+vp5Z5EksawfCWo2zkAc6o7CClc0eff1Pjrqznlwg=="
     },
     "node_modules/@discordjs/collection": {
       "version": "1.0.0",
@@ -55,6 +61,11 @@
       "engines": {
         "node": ">=16.9.0"
       }
+    },
+    "node_modules/@discordjs/rest/node_modules/discord-api-types": {
+      "version": "0.36.3",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.36.3.tgz",
+      "integrity": "sha512-bz/NDyG0KBo/tY14vSkrwQ/n3HKPf87a0WFW/1M9+tXYK+vp5Z5EksawfCWo2zkAc6o7CClc0eff1Pjrqznlwg=="
     },
     "node_modules/@sapphire/async-queue": {
       "version": "1.3.2",
@@ -204,9 +215,9 @@
       }
     },
     "node_modules/discord-api-types": {
-      "version": "0.36.3",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.36.3.tgz",
-      "integrity": "sha512-bz/NDyG0KBo/tY14vSkrwQ/n3HKPf87a0WFW/1M9+tXYK+vp5Z5EksawfCWo2zkAc6o7CClc0eff1Pjrqznlwg=="
+      "version": "0.37.2",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.2.tgz",
+      "integrity": "sha512-JS4q0LGRxqY7TIsfORlIMzcmews+Qu3RmOWrxoEY+BR0g0sZlplEyY/Ltb3om6ZaBm+WNcAmAJxlsmAu4068Vw=="
     },
     "node_modules/discord.js": {
       "version": "14.0.3",
@@ -228,6 +239,11 @@
       "engines": {
         "node": ">=16.9.0"
       }
+    },
+    "node_modules/discord.js/node_modules/discord-api-types": {
+      "version": "0.36.3",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.36.3.tgz",
+      "integrity": "sha512-bz/NDyG0KBo/tY14vSkrwQ/n3HKPf87a0WFW/1M9+tXYK+vp5Z5EksawfCWo2zkAc6o7CClc0eff1Pjrqznlwg=="
     },
     "node_modules/dotenv": {
       "version": "16.0.1",
@@ -714,6 +730,13 @@
         "fast-deep-equal": "^3.1.3",
         "ts-mixer": "^6.0.1",
         "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "discord-api-types": {
+          "version": "0.36.3",
+          "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.36.3.tgz",
+          "integrity": "sha512-bz/NDyG0KBo/tY14vSkrwQ/n3HKPf87a0WFW/1M9+tXYK+vp5Z5EksawfCWo2zkAc6o7CClc0eff1Pjrqznlwg=="
+        }
       }
     },
     "@discordjs/collection": {
@@ -733,6 +756,13 @@
         "file-type": "^17.1.2",
         "tslib": "^2.4.0",
         "undici": "^5.7.0"
+      },
+      "dependencies": {
+        "discord-api-types": {
+          "version": "0.36.3",
+          "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.36.3.tgz",
+          "integrity": "sha512-bz/NDyG0KBo/tY14vSkrwQ/n3HKPf87a0WFW/1M9+tXYK+vp5Z5EksawfCWo2zkAc6o7CClc0eff1Pjrqznlwg=="
+        }
       }
     },
     "@sapphire/async-queue": {
@@ -851,9 +881,9 @@
       }
     },
     "discord-api-types": {
-      "version": "0.36.3",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.36.3.tgz",
-      "integrity": "sha512-bz/NDyG0KBo/tY14vSkrwQ/n3HKPf87a0WFW/1M9+tXYK+vp5Z5EksawfCWo2zkAc6o7CClc0eff1Pjrqznlwg=="
+      "version": "0.37.2",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.2.tgz",
+      "integrity": "sha512-JS4q0LGRxqY7TIsfORlIMzcmews+Qu3RmOWrxoEY+BR0g0sZlplEyY/Ltb3om6ZaBm+WNcAmAJxlsmAu4068Vw=="
     },
     "discord.js": {
       "version": "14.0.3",
@@ -871,6 +901,13 @@
         "tslib": "^2.4.0",
         "undici": "^5.8.0",
         "ws": "^8.8.1"
+      },
+      "dependencies": {
+        "discord-api-types": {
+          "version": "0.36.3",
+          "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.36.3.tgz",
+          "integrity": "sha512-bz/NDyG0KBo/tY14vSkrwQ/n3HKPf87a0WFW/1M9+tXYK+vp5Z5EksawfCWo2zkAc6o7CClc0eff1Pjrqznlwg=="
+        }
       }
     },
     "dotenv": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/FitDevs-withKat/discord-bot#readme",
   "dependencies": {
+    "discord-api-types": "^0.37.2",
     "discord.js": "^14.0.3",
     "dotenv": "^16.0.1"
   },


### PR DESCRIPTION
**Description**: Added a commands folder with two example slash commands. These commands are registered in `index js` through reading the commands directory using `fs` node module.

I find that this is a scalable solution that enforces a separation of concerns for commands. Refactoring for `index js` may need to take place to create a handler if events are later introduced into this project.

Currently uses Discord JS v14 and REST v10.

**Dependency added**: `discord-api-types`

**Tutorial referenced**: https://www.youtube.com/watch?v=JdpJiPlVeaU
